### PR TITLE
Replace string errors with pre-defiined type.

### DIFF
--- a/generator/common.go
+++ b/generator/common.go
@@ -26,7 +26,17 @@ func generateCommonFiles(packageName, outputDir string) error {
 	type TdMessage interface{
 		MessageType() string
 	}
-	
+
+	// RequestError represents an error returned from tdlib.
+	type RequestError struct {
+		Code int
+		Message string
+	}
+
+	func (re RequestError) Error() string {
+		return "error! code: " + strconv.FormatInt(int64(re.Code), 10) + " msg: " + re.Message
+	}
+
 	// JSONInt64 alias for int64, in order to deal with json big number problem
 	type JSONInt64 int64
 

--- a/generator/function.go
+++ b/generator/function.go
@@ -107,7 +107,7 @@ func GenerateMethods(schema *tlparser.TlSchema, basePackageUri, typePackageName,
 			}
 		}
 
-		illStr := `fmt.Errorf("error! code: %d msg: %s", result.Data["code"], result.Data["message"])`
+		illStr := typePackageName + `.RequestError{Code: int(result.Data["code"].(float64)), Message: result.Data["message"].(string)}`
 		if strings.Contains(paramsStr, returnTypeCamel) {
 			returnTypeCamel = returnTypeCamel + "Dummy"
 		}


### PR DESCRIPTION
This will allow to extract error code and message without resulting error message parsing.

For some methods it is now required to check for error code to see if action succeeded: https://github.com/tdlib/td/blob/41c391f140a1450b0541201c560d30455158690c/td/generate/scheme/td_api.tl#L4092

Error message is not changed to preserve text representation.